### PR TITLE
Add alias for Parsedown in Comment module

### DIFF
--- a/comment_controller.php
+++ b/comment_controller.php
@@ -1,6 +1,6 @@
 <?php
 
-use \Parsedown;
+use \Parsedown as Parsedown;
 
 /**
  * Comment_controller class


### PR DESCRIPTION
Resolves issue with missing Edit button in comment_detail widget

Before:
![broken](https://user-images.githubusercontent.com/12276948/89910547-fee1dd00-dbb5-11ea-81e5-8aa5006a5dbb.PNG)

After:
![Fixed](https://user-images.githubusercontent.com/12276948/89910538-fbe6ec80-dbb5-11ea-8a33-469a5643745e.PNG)